### PR TITLE
feat: add smart lists and richer reminder attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 *.njsproj
 *.sln
 *.sw?
+.codex/
 
 # OS specific
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # MCP Apple Reminders
 
-A Model Context Protocol (MCP) server for interacting with Apple Reminders on macOS.
+Model Context Protocol (MCP) server for interacting with Apple Reminders on macOS.
 
 ## Features
 
-- **List Management**: View all reminder lists in your Apple Reminders app
-- **Reminder Retrieval**: Get all reminders from a specific list
-- **Create Reminders**: Create new reminders with titles, due dates, and notes
-- **Complete Reminders**: Mark reminders as completed
-- **Delete Reminders**: Remove reminders from your lists
-- **Date Handling**: Proper handling of ISO date formats for due dates
+- List reminder lists (`getLists`)
+- Read reminders from a list (`getReminders`)
+- Create reminders with optional due date and notes (`createReminder`)
+- Mark reminders complete (`completeReminder`)
+- Delete reminders (`deleteReminder`)
+- Standardized JSON responses with error details for easier client handling
 
-## Configuration
+## Requirements
 
-### Usage with Claude Desktop
+- macOS (Apple Reminders automation is macOS-only)
+- Node.js 18+
+- Yarn 1.x
+- Apple Reminders configured with at least one list
 
-Add this to your `claude_desktop_config.json`:
+## Install
+
+```bash
+yarn install
+yarn build
+```
+
+## Use with MCP Clients
+
+Example `claude_desktop_config.json` entry:
 
 ```json
 {
@@ -23,75 +35,75 @@ Add this to your `claude_desktop_config.json`:
     "apple-reminders": {
       "command": "node",
       "args": [
-        "/path/to/mcp-apple-reminders/dist/index.js"
+        "/absolute/path/to/apple-reminders-mcp/dist/index.js"
       ]
     }
   }
 }
 ```
 
-### NPX (Coming Soon)
+## Tool API
 
-```json
-{
-  "mcpServers": {
-    "apple-reminders": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-apple-reminders"
-      ]
-    }
-  }
-}
-```
+### `getLists`
 
-## API
+Returns all reminder list names.
 
-The server exposes the following MCP tools for interacting with Apple Reminders:
+### `getReminders`
 
-### getLists
-Returns all reminder lists.
+Parameters:
+- `listName` (string, required)
 
-### getReminders
-Returns reminders from a specific list.
-- Parameters:
-  - `listName` (required): The name of the reminder list
+Returns reminders from the given list with:
+- `name`
+- `completed`
+- `dueDate` (ISO string or `null`)
+- `priority`
+- `notes` (string or `null`)
 
-### createReminder
-Creates a new reminder.
-- Parameters:
-  - `listName` (required): The name of the reminder list
-  - `title` (required): The title of the reminder
-  - `dueDate` (optional): The due date for the reminder (ISO format: "YYYY-MM-DDTHH:MM:SS.sssZ")
-  - `notes` (optional): Notes for the reminder
+### `createReminder`
 
-### completeReminder
-Marks a reminder as completed.
-- Parameters:
-  - `listName` (required): The name of the reminder list
-  - `reminderName` (required): The name of the reminder to complete
+Parameters:
+- `listName` (string, required)
+- `title` (string, required)
+- `dueDate` (string, optional; must be a valid date string)
+- `notes` (string, optional)
 
-### deleteReminder
-Deletes a reminder.
-- Parameters:
-  - `listName` (required): The name of the reminder list
-  - `reminderName` (required): The name of the reminder to delete
+### `completeReminder`
 
-## How It Works
+Parameters:
+- `listName` (string, required)
+- `reminderName` (string, required)
 
-This MCP server uses AppleScript to interact with the Apple Reminders app on macOS. It provides a standardized interface for AI assistants to manage reminders through the Model Context Protocol.
+Marks the first reminder with matching name as completed.
+
+### `deleteReminder`
+
+Parameters:
+- `listName` (string, required)
+- `reminderName` (string, required)
+
+Deletes the first reminder with matching name.
 
 ## Development
 
-This project uses TypeScript and the MCP SDK. To extend functionality, modify the tools in `src/index.ts` and the AppleScript functions in `src/reminders.ts`.
+Scripts:
 
-## Requirements
+- `yarn build` compiles TypeScript to `dist/`
+- `yarn typecheck` runs type-checking without emitting files
+- `yarn dev` starts from TypeScript source
+- `yarn test` runs integration tests (`build` + test runner)
 
-- macOS (required for Apple Reminders integration)
-- Node.js 16+
-- Apple Reminders app configured with at least one list
+Test notes:
+
+- `yarn test` interacts with real Apple Reminders data.
+- It creates, completes, and deletes a temporary reminder in your first available list.
+
+## Implementation Notes
+
+- Core MCP tool registration: `src/index.ts`
+- Apple Reminders integration wrapper: `src/reminders.ts`
+- Integration test flow: `src/tests/test-reminders.ts`
 
 ## License
 
-MIT 
+MIT

--- a/package.json
+++ b/package.json
@@ -7,18 +7,17 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "dev": "ts-node --esm src/index.ts",
-    "test": "node dist/tests/test-reminders.js"
+    "test": "yarn build && node dist/tests/test-reminders.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "express": "^5.2.1",
     "node-reminders": "^1.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/express": "^5.0.6",
     "@types/node": "^25.2.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "test": "node dist/tests/test-reminders.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.6.1",
-    "express": "^4.18.2",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "express": "^5.2.1",
     "node-reminders": "^1.0.0",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/express": "^4.17.17",
-    "@types/node": "^18.15.11",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "@types/express": "^5.0.6",
+    "@types/node": "^25.2.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,32 @@ function failureResponse(message: string, error: unknown): ToolResponse {
 }
 
 const nonEmptyString = z.string().trim().min(1);
+const priorityValue = z.number().int().min(0).max(9);
+const tagValue = z.string().trim().min(1);
+
+const locationSchema = z
+  .object({
+    title: z.string().trim().min(1).optional(),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    radiusMeters: z.number().positive().optional(),
+    proximity: z.enum(["arriving", "leaving"]).optional()
+  })
+  .refine(
+    (value) =>
+      (value.latitude === undefined && value.longitude === undefined) ||
+      (value.latitude !== undefined && value.longitude !== undefined),
+    "location.latitude and location.longitude must be provided together"
+  )
+  .refine(
+    (value) =>
+      value.title !== undefined ||
+      value.latitude !== undefined ||
+      value.longitude !== undefined ||
+      value.radiusMeters !== undefined ||
+      value.proximity !== undefined,
+    "location must include at least one field"
+  );
 
 // Create a simple MCP server for Apple Reminders
 const server = new McpServer({
@@ -88,17 +114,75 @@ server.tool(
         (value) => value === undefined || !Number.isNaN(new Date(value).getTime()),
         "dueDate must be a valid date string"
       ),
-    notes: z.string().optional()
+    notes: z.string().optional(),
+    flagged: z.boolean().optional(),
+    priority: priorityValue.optional(),
+    tags: z.array(tagValue).optional(),
+    location: locationSchema.optional()
   },
-  async ({ listName, title, dueDate, notes }) => {
+  async ({ listName, title, dueDate, notes, flagged, priority, tags, location }) => {
     try {
-      const success = await reminders.createReminder(listName, title, dueDate, notes);
+      const success = await reminders.createReminder(
+        listName,
+        title,
+        dueDate,
+        notes,
+        flagged,
+        priority,
+        tags,
+        location
+      );
       return successResponse({
         success,
         message: success ? "Reminder created" : "Failed to create reminder"
       });
     } catch (error) {
       return failureResponse("Failed to create reminder", error);
+    }
+  }
+);
+
+// Tool to get tags from reminders
+server.tool(
+  "getTags",
+  {
+    listName: nonEmptyString.optional()
+  },
+  async ({ listName }) => {
+    try {
+      const tags = await reminders.getTags(listName);
+      return successResponse({ tags });
+    } catch (error) {
+      return failureResponse("Failed to get tags", error);
+    }
+  }
+);
+
+// Tool to set reminder attributes (flag/priority/tags/location)
+server.tool(
+  "setReminderAttributes",
+  {
+    listName: nonEmptyString,
+    reminderName: nonEmptyString,
+    flagged: z.boolean().optional(),
+    priority: priorityValue.optional(),
+    tags: z.array(tagValue).optional(),
+    location: locationSchema.nullable().optional()
+  },
+  async ({ listName, reminderName, flagged, priority, tags, location }) => {
+    try {
+      const success = await reminders.setReminderAttributes(listName, reminderName, {
+        flagged,
+        priority,
+        tags,
+        location
+      });
+      return successResponse({
+        success,
+        message: success ? "Reminder attributes updated" : "Reminder not found"
+      });
+    } catch (error) {
+      return failureResponse("Failed to set reminder attributes", error);
     }
   }
 );

--- a/src/reminders.ts
+++ b/src/reminders.ts
@@ -1,17 +1,58 @@
-import * as reminders from 'node-reminders';
+import * as reminders from "node-reminders";
+
+type ReminderList = Awaited<ReturnType<typeof reminders.getLists>>[number];
+type ReminderItem = Awaited<ReturnType<typeof reminders.getReminders>>[number];
+
+interface ReminderCreatePayload {
+  name: string;
+  dueDate?: Date;
+  body?: string;
+}
+
+export interface ReminderRecord {
+  name: string;
+  completed: boolean;
+  dueDate: string | null;
+  priority: number;
+  notes: string | null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function getListByName(listName: string): Promise<ReminderList> {
+  const lists = await reminders.getLists();
+  const targetList = lists.find((list) => list.name === listName);
+  if (!targetList) {
+    throw new Error(`List "${listName}" not found`);
+  }
+  return targetList;
+}
+
+function parseDueDate(dueDate: string): Date {
+  const parsedDate = new Date(dueDate);
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error(`Invalid dueDate "${dueDate}". Use an ISO-compatible date string.`);
+  }
+  return parsedDate;
+}
 
 /**
  * Format a date string for consistency
  */
-function formatDate(date: Date | string | null): string | null {
+function formatDate(date: Date | string | null | undefined): string | null {
   if (!date) return null;
-  
+
   try {
-    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    const dateObj = typeof date === "string" ? new Date(date) : date;
     if (isNaN(dateObj.getTime())) return null;
     return dateObj.toISOString();
   } catch (error) {
-    console.error('Date formatting error:', error);
+    console.error("Date formatting error:", error);
     return null;
   }
 }
@@ -22,79 +63,74 @@ function formatDate(date: Date | string | null): string | null {
 export async function getRemindersLists(): Promise<string[]> {
   try {
     const lists = await reminders.getLists();
-    return lists.map(list => list.name);
+    return lists.map((list) => list.name);
   } catch (error) {
-    console.error('Failed to get reminder lists:', error);
-    throw new Error(`Failed to get reminder lists: ${error}`);
+    console.error("Failed to get reminder lists:", error);
+    throw new Error(`Failed to get reminder lists: ${getErrorMessage(error)}`);
   }
 }
 
 /**
  * Get reminders from a specific list
  */
-export async function getRemindersFromList(listName: string): Promise<any[]> {
+export async function getRemindersFromList(listName: string): Promise<ReminderRecord[]> {
   try {
-    // First get the list ID by name
-    const lists = await reminders.getLists();
-    const targetList = lists.find(list => list.name === listName);
-    
-    if (!targetList) {
-      throw new Error(`List "${listName}" not found`);
-    }
-    
+    const targetList = await getListByName(listName);
+
     // Get reminders from the list with specific properties
-    const reminderItems = await reminders.getReminders(
+    const reminderItems = (await reminders.getReminders(
       targetList.id,
-      ['name', 'completed', 'dueDate', 'priority', 'body']
-    );
-    
+      ["name", "completed", "dueDate", "priority", "body"]
+    )) as ReadonlyArray<Partial<ReminderItem>>;
+
     // Format the reminders to match the expected output format
-    return reminderItems.map(item => ({
-      name: item.name,
-      completed: item.completed || false,
+    return reminderItems.map((item) => ({
+      name: item.name ?? "",
+      completed: item.completed ?? false,
       dueDate: formatDate(item.dueDate),
-      priority: item.priority || 0,
-      notes: item.body
+      priority: item.priority ?? 0,
+      notes: item.body ?? null
     }));
   } catch (error) {
     console.error(`Failed to get reminders from list "${listName}":`, error);
-    throw new Error(`Failed to get reminders from list "${listName}": ${error}`);
+    throw new Error(
+      `Failed to get reminders from list "${listName}": ${getErrorMessage(error)}`
+    );
   }
 }
 
 /**
  * Create a new reminder
  */
-export async function createReminder(listName: string, title: string, dueDate?: string, notes?: string): Promise<boolean> {
+export async function createReminder(
+  listName: string,
+  title: string,
+  dueDate?: string,
+  notes?: string
+): Promise<boolean> {
   try {
-    // First get the list ID by name
-    const lists = await reminders.getLists();
-    const targetList = lists.find(list => list.name === listName);
-    
-    if (!targetList) {
-      throw new Error(`List "${listName}" not found`);
-    }
-    
+    const targetList = await getListByName(listName);
+
     // Prepare reminder data
-    const reminderData: any = {
+    const reminderData: ReminderCreatePayload = {
       name: title
     };
-    
+
     if (dueDate) {
-      reminderData.dueDate = new Date(dueDate);
+      reminderData.dueDate = parseDueDate(dueDate);
     }
-    
+
     if (notes) {
       reminderData.body = notes;
     }
-    
+
     // Create the reminder
     const newReminderId = await reminders.createReminder(targetList.id, reminderData);
-    
+
     return !!newReminderId;
   } catch (error) {
     console.error(`Failed to create reminder "${title}" in list "${listName}":`, error);
-    throw new Error(`Failed to create reminder: ${error}`);
+    throw new Error(`Failed to create reminder: ${getErrorMessage(error)}`);
   }
 }
 
@@ -103,36 +139,33 @@ export async function createReminder(listName: string, title: string, dueDate?: 
  */
 export async function completeReminder(listName: string, reminderName: string): Promise<boolean> {
   try {
-    // First get the list ID by name
-    const lists = await reminders.getLists();
-    const targetList = lists.find(list => list.name === listName);
-    
-    if (!targetList) {
-      throw new Error(`List "${listName}" not found`);
-    }
-    
+    const targetList = await getListByName(listName);
+
     // Get all reminders from the list
-    const reminderItems = await reminders.getReminders(
+    const reminderItems = (await reminders.getReminders(
       targetList.id,
-      ['name', 'id']
-    );
-    
+      ["name", "id"]
+    )) as ReadonlyArray<Partial<ReminderItem>>;
+
     // Find the specific reminder by name
-    const targetReminder = reminderItems.find(item => item.name === reminderName);
-    
+    const targetReminder = reminderItems.find(
+      (item): item is Partial<ReminderItem> & { id: string } =>
+        item.name === reminderName && typeof item.id === "string"
+    );
+
     if (!targetReminder) {
       return false; // Reminder not found
     }
-    
+
     // Update the reminder to mark it as completed
     await reminders.updateReminder(targetReminder.id, {
       completed: true
     });
-    
+
     return true;
   } catch (error) {
     console.error(`Failed to complete reminder "${reminderName}" in list "${listName}":`, error);
-    throw new Error(`Failed to complete reminder: ${error}`);
+    throw new Error(`Failed to complete reminder: ${getErrorMessage(error)}`);
   }
 }
 
@@ -141,33 +174,30 @@ export async function completeReminder(listName: string, reminderName: string): 
  */
 export async function deleteReminder(listName: string, reminderName: string): Promise<boolean> {
   try {
-    // First get the list ID by name
-    const lists = await reminders.getLists();
-    const targetList = lists.find(list => list.name === listName);
-    
-    if (!targetList) {
-      throw new Error(`List "${listName}" not found`);
-    }
-    
+    const targetList = await getListByName(listName);
+
     // Get all reminders from the list
-    const reminderItems = await reminders.getReminders(
+    const reminderItems = (await reminders.getReminders(
       targetList.id,
-      ['name', 'id']
-    );
-    
+      ["name", "id"]
+    )) as ReadonlyArray<Partial<ReminderItem>>;
+
     // Find the specific reminder by name
-    const targetReminder = reminderItems.find(item => item.name === reminderName);
-    
+    const targetReminder = reminderItems.find(
+      (item): item is Partial<ReminderItem> & { id: string } =>
+        item.name === reminderName && typeof item.id === "string"
+    );
+
     if (!targetReminder) {
       return false; // Reminder not found
     }
-    
+
     // Delete the reminder
     await reminders.deleteReminder(targetReminder.id);
-    
+
     return true;
   } catch (error) {
     console.error(`Failed to delete reminder "${reminderName}" in list "${listName}":`, error);
-    throw new Error(`Failed to delete reminder: ${error}`);
+    throw new Error(`Failed to delete reminder: ${getErrorMessage(error)}`);
   }
-} 
+}

--- a/src/reminders.ts
+++ b/src/reminders.ts
@@ -2,19 +2,75 @@ import * as reminders from "node-reminders";
 
 type ReminderList = Awaited<ReturnType<typeof reminders.getLists>>[number];
 type ReminderItem = Awaited<ReturnType<typeof reminders.getReminders>>[number];
+type ReminderProp = keyof ReminderItem | "flagged";
+
+type ReminderItemWithExtras = Partial<ReminderItem> & {
+  id?: string;
+  name?: string;
+  body?: string | null;
+  completed?: boolean;
+  dueDate?: Date | string | null;
+  priority?: number;
+  flagged?: boolean;
+};
+
+const METADATA_PREFIX = "[[mcp-reminder-meta:";
+const METADATA_SUFFIX = "]]";
+const SMART_LIST_PREFIX = "Smart: ";
+const SMART_FILTER_PROPS = ["id", "name", "completed", "dueDate", "flagged"] as const;
 
 interface ReminderCreatePayload {
   name: string;
   dueDate?: Date;
   body?: string;
+  priority?: number;
+  flagged?: boolean;
+}
+
+interface SmartListDefinition {
+  name: string;
+  aliases?: string[];
+  predicate: (item: ReminderItemWithExtras) => boolean;
+}
+
+type ResolvedList =
+  | { kind: "regular"; list: ReminderList }
+  | { kind: "smart"; smartList: SmartListDefinition };
+
+export interface ReminderLocation {
+  title?: string;
+  latitude?: number;
+  longitude?: number;
+  radiusMeters?: number;
+  proximity?: "arriving" | "leaving";
+}
+
+interface ReminderMetadata {
+  tags?: string[];
+  location?: ReminderLocation;
+}
+
+interface ReminderBodyParts {
+  notes: string | null;
+  metadata: ReminderMetadata;
+}
+
+interface ReminderAttributesUpdate {
+  flagged?: boolean;
+  priority?: number;
+  tags?: string[];
+  location?: ReminderLocation | null;
 }
 
 export interface ReminderRecord {
   name: string;
   completed: boolean;
   dueDate: string | null;
+  flagged: boolean;
   priority: number;
   notes: string | null;
+  tags: string[];
+  location: ReminderLocation | null;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -24,13 +80,52 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
-async function getListByName(listName: string): Promise<ReminderList> {
-  const lists = await reminders.getLists();
-  const targetList = lists.find((list) => list.name === listName);
-  if (!targetList) {
-    throw new Error(`List "${listName}" not found`);
+function normalizeListName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeDateValue(date: Date | string | null | undefined): Date | null {
+  if (!date) return null;
+
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(dateObj.getTime())) return null;
+  // node-reminders may represent "no due date" as Unix epoch.
+  if (dateObj.getTime() === 0) return null;
+  return dateObj;
+}
+
+function isCompleted(item: ReminderItemWithExtras): boolean {
+  return item.completed ?? false;
+}
+
+function isFlagged(item: ReminderItemWithExtras): boolean {
+  return item.flagged ?? false;
+}
+
+function dueDateOf(item: ReminderItemWithExtras): Date | null {
+  return normalizeDateValue(item.dueDate);
+}
+
+function isDueToday(item: ReminderItemWithExtras): boolean {
+  const dueDate = dueDateOf(item);
+  if (!dueDate) {
+    return false;
   }
-  return targetList;
+
+  const now = new Date();
+  return (
+    dueDate.getFullYear() === now.getFullYear() &&
+    dueDate.getMonth() === now.getMonth() &&
+    dueDate.getDate() === now.getDate()
+  );
+}
+
+function isOverdue(item: ReminderItemWithExtras): boolean {
+  const dueDate = dueDateOf(item);
+  if (!dueDate || isCompleted(item)) {
+    return false;
+  }
+  return dueDate.getTime() < Date.now();
 }
 
 function parseDueDate(dueDate: string): Date {
@@ -41,20 +136,326 @@ function parseDueDate(dueDate: string): Date {
   return parsedDate;
 }
 
+const SMART_LISTS: ReadonlyArray<SmartListDefinition> = [
+  {
+    name: "All",
+    aliases: ["all reminders"],
+    predicate: () => true
+  },
+  {
+    name: "Today",
+    predicate: (item) => !isCompleted(item) && isDueToday(item)
+  },
+  {
+    name: "Scheduled",
+    aliases: ["planned"],
+    predicate: (item) => !isCompleted(item) && dueDateOf(item) !== null
+  },
+  {
+    name: "Flagged",
+    predicate: (item) => !isCompleted(item) && isFlagged(item)
+  },
+  {
+    name: "Completed",
+    predicate: (item) => isCompleted(item)
+  },
+  {
+    name: "Overdue",
+    predicate: (item) => isOverdue(item)
+  }
+];
+
+function smartListDisplayName(smartListName: string): string {
+  return `${SMART_LIST_PREFIX}${smartListName}`;
+}
+
+function getSmartListByName(listName: string): SmartListDefinition | null {
+  const normalizedName = normalizeListName(listName);
+  const normalizedStrippedName = normalizedName.startsWith("smart:")
+    ? normalizedName.slice("smart:".length).trim()
+    : normalizedName;
+
+  for (const smartList of SMART_LISTS) {
+    const canonicalName = normalizeListName(smartList.name);
+    if (normalizedStrippedName === canonicalName || normalizedName === canonicalName) {
+      return smartList;
+    }
+
+    if (smartList.aliases?.some((alias) => normalizeListName(alias) === normalizedStrippedName)) {
+      return smartList;
+    }
+  }
+
+  return null;
+}
+
+async function getRegularListByName(listName: string): Promise<ReminderList | null> {
+  const lists = await reminders.getLists();
+  const normalizedName = normalizeListName(listName);
+  return (
+    lists.find((list) => normalizeListName(list.name) === normalizedName) ??
+    null
+  );
+}
+
+async function resolveListByName(listName: string): Promise<ResolvedList> {
+  const regularList = await getRegularListByName(listName);
+  if (regularList) {
+    return { kind: "regular", list: regularList };
+  }
+
+  const smartList = getSmartListByName(listName);
+  if (smartList) {
+    return { kind: "smart", smartList };
+  }
+
+  throw new Error(`List "${listName}" not found`);
+}
+
+function mergeReminderProps(
+  ...propSets: ReadonlyArray<ReadonlyArray<ReminderProp>>
+): ReadonlyArray<ReminderProp> {
+  const mergedProps = new Set<ReminderProp>();
+  for (const propSet of propSets) {
+    for (const prop of propSet) {
+      mergedProps.add(prop);
+    }
+  }
+  return Array.from(mergedProps);
+}
+
+async function fetchRemindersByListId(
+  listId: string,
+  props: ReadonlyArray<ReminderProp>
+): Promise<ReadonlyArray<ReminderItemWithExtras>> {
+  return (await reminders.getReminders(
+    listId,
+    props as unknown as ReadonlyArray<keyof ReminderItem>
+  )) as ReadonlyArray<ReminderItemWithExtras>;
+}
+
+async function fetchAllReminders(
+  props: ReadonlyArray<ReminderProp>
+): Promise<ReadonlyArray<ReminderItemWithExtras>> {
+  const lists = await reminders.getLists();
+  const mergedProps = mergeReminderProps(props, SMART_FILTER_PROPS);
+
+  const remindersByList = await Promise.all(
+    lists.map((list) => fetchRemindersByListId(list.id, mergedProps))
+  );
+
+  const allItems: ReminderItemWithExtras[] = [];
+  const seenIds = new Set<string>();
+
+  for (const listItems of remindersByList) {
+    for (const item of listItems) {
+      if (typeof item.id === "string") {
+        if (seenIds.has(item.id)) {
+          continue;
+        }
+        seenIds.add(item.id);
+      }
+      allItems.push(item);
+    }
+  }
+
+  return allItems;
+}
+
+async function fetchRemindersForList(
+  listName: string,
+  props: ReadonlyArray<ReminderProp>
+): Promise<ReadonlyArray<ReminderItemWithExtras>> {
+  const resolvedList = await resolveListByName(listName);
+
+  if (resolvedList.kind === "regular") {
+    return fetchRemindersByListId(resolvedList.list.id, props);
+  }
+
+  const mergedProps = mergeReminderProps(props, SMART_FILTER_PROPS);
+  const allItems = await fetchAllReminders(mergedProps);
+  return allItems.filter((item) => resolvedList.smartList.predicate(item));
+}
+
 /**
  * Format a date string for consistency
  */
 function formatDate(date: Date | string | null | undefined): string | null {
-  if (!date) return null;
-
   try {
-    const dateObj = typeof date === "string" ? new Date(date) : date;
-    if (isNaN(dateObj.getTime())) return null;
+    const dateObj = normalizeDateValue(date);
+    if (!dateObj) return null;
     return dateObj.toISOString();
   } catch (error) {
     console.error("Date formatting error:", error);
     return null;
   }
+}
+
+function normalizeTags(tags: string[] | undefined): string[] {
+  if (!tags) {
+    return [];
+  }
+
+  const deduped = new Map<string, string>();
+  for (const tag of tags) {
+    const normalized = tag.trim().replace(/^#+/, "");
+    if (!normalized) {
+      continue;
+    }
+    const key = normalized.toLowerCase();
+    if (!deduped.has(key)) {
+      deduped.set(key, normalized);
+    }
+  }
+
+  return Array.from(deduped.values());
+}
+
+function normalizeLocation(
+  location: ReminderLocation | null | undefined,
+  strict: boolean
+): ReminderLocation | null {
+  if (!location) {
+    return null;
+  }
+
+  const normalized: ReminderLocation = {};
+
+  if (typeof location.title === "string" && location.title.trim()) {
+    normalized.title = location.title.trim();
+  }
+
+  if (typeof location.latitude === "number" && Number.isFinite(location.latitude)) {
+    if (location.latitude < -90 || location.latitude > 90) {
+      if (strict) {
+        throw new Error("location.latitude must be between -90 and 90");
+      }
+    } else {
+      normalized.latitude = location.latitude;
+    }
+  }
+
+  if (typeof location.longitude === "number" && Number.isFinite(location.longitude)) {
+    if (location.longitude < -180 || location.longitude > 180) {
+      if (strict) {
+        throw new Error("location.longitude must be between -180 and 180");
+      }
+    } else {
+      normalized.longitude = location.longitude;
+    }
+  }
+
+  if (typeof location.radiusMeters === "number" && Number.isFinite(location.radiusMeters)) {
+    if (location.radiusMeters <= 0) {
+      if (strict) {
+        throw new Error("location.radiusMeters must be greater than 0");
+      }
+    } else {
+      normalized.radiusMeters = location.radiusMeters;
+    }
+  }
+
+  if (location.proximity === "arriving" || location.proximity === "leaving") {
+    normalized.proximity = location.proximity;
+  } else if (location.proximity !== undefined && strict) {
+    throw new Error('location.proximity must be "arriving" or "leaving"');
+  }
+
+  const hasLatitude = normalized.latitude !== undefined;
+  const hasLongitude = normalized.longitude !== undefined;
+  if (hasLatitude !== hasLongitude) {
+    if (strict) {
+      throw new Error("location.latitude and location.longitude must be provided together");
+    }
+    delete normalized.latitude;
+    delete normalized.longitude;
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function encodeMetadata(metadata: ReminderMetadata): string | null {
+  const tags = normalizeTags(metadata.tags);
+  const location = normalizeLocation(metadata.location, false);
+  const compactMetadata: ReminderMetadata = {};
+
+  if (tags.length > 0) {
+    compactMetadata.tags = tags;
+  }
+  if (location) {
+    compactMetadata.location = location;
+  }
+
+  if (Object.keys(compactMetadata).length === 0) {
+    return null;
+  }
+
+  return Buffer.from(JSON.stringify(compactMetadata), "utf8").toString("base64url");
+}
+
+function composeReminderBody(notes: string | undefined, metadata: ReminderMetadata): string | undefined {
+  const encodedMetadata = encodeMetadata(metadata);
+  const hasNotes = typeof notes === "string" && notes.trim().length > 0;
+
+  if (!encodedMetadata) {
+    return hasNotes ? notes : undefined;
+  }
+
+  const marker = `${METADATA_PREFIX}${encodedMetadata}${METADATA_SUFFIX}`;
+  return hasNotes ? `${notes}\n\n${marker}` : marker;
+}
+
+function parseReminderBody(body: string | null | undefined): ReminderBodyParts {
+  if (!body) {
+    return { notes: null, metadata: {} };
+  }
+
+  const metadataPattern = /\s*\[\[mcp-reminder-meta:([A-Za-z0-9_-]+)\]\]\s*$/;
+  const match = body.match(metadataPattern);
+  if (!match) {
+    return { notes: body, metadata: {} };
+  }
+
+  const encoded = match[1];
+  const markerIndex = match.index ?? body.length;
+  const notesPortion = body.slice(0, markerIndex).trimEnd();
+
+  try {
+    const decoded = Buffer.from(encoded, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as ReminderMetadata;
+    return {
+      notes: notesPortion || null,
+      metadata: {
+        tags: normalizeTags(parsed.tags),
+        location: normalizeLocation(parsed.location, false) ?? undefined
+      }
+    };
+  } catch (error) {
+    console.error("Failed to parse reminder metadata:", error);
+    return { notes: body, metadata: {} };
+  }
+}
+
+async function getReminderByName(
+  listName: string,
+  reminderName: string,
+  properties: ReadonlyArray<ReminderProp>
+): Promise<(ReminderItemWithExtras & { id: string }) | null> {
+  const reminderItems = await fetchRemindersForList(
+    listName,
+    mergeReminderProps(properties, ["id", "name"])
+  );
+
+  const targetReminder = reminderItems.find(
+    (item): item is ReminderItemWithExtras & { id: string } =>
+      item.name === reminderName && typeof item.id === "string"
+  );
+
+  return targetReminder ?? null;
 }
 
 /**
@@ -63,7 +464,11 @@ function formatDate(date: Date | string | null | undefined): string | null {
 export async function getRemindersLists(): Promise<string[]> {
   try {
     const lists = await reminders.getLists();
-    return lists.map((list) => list.name);
+    const regularListNames = lists.map((list) => list.name);
+    const smartListNames = SMART_LISTS.map((smartList) =>
+      smartListDisplayName(smartList.name)
+    );
+    return [...regularListNames, ...smartListNames];
   } catch (error) {
     console.error("Failed to get reminder lists:", error);
     throw new Error(`Failed to get reminder lists: ${getErrorMessage(error)}`);
@@ -75,27 +480,62 @@ export async function getRemindersLists(): Promise<string[]> {
  */
 export async function getRemindersFromList(listName: string): Promise<ReminderRecord[]> {
   try {
-    const targetList = await getListByName(listName);
-
-    // Get reminders from the list with specific properties
-    const reminderItems = (await reminders.getReminders(
-      targetList.id,
-      ["name", "completed", "dueDate", "priority", "body"]
-    )) as ReadonlyArray<Partial<ReminderItem>>;
+    const reminderItems = await fetchRemindersForList(listName, [
+      "name",
+      "completed",
+      "dueDate",
+      "priority",
+      "body",
+      "flagged"
+    ]);
 
     // Format the reminders to match the expected output format
-    return reminderItems.map((item) => ({
-      name: item.name ?? "",
-      completed: item.completed ?? false,
-      dueDate: formatDate(item.dueDate),
-      priority: item.priority ?? 0,
-      notes: item.body ?? null
-    }));
+    return reminderItems.map((item) => {
+      const bodyParts = parseReminderBody(item.body);
+      return {
+        name: item.name ?? "",
+        completed: item.completed ?? false,
+        dueDate: formatDate(item.dueDate),
+        flagged: item.flagged ?? false,
+        priority: item.priority ?? 0,
+        notes: bodyParts.notes,
+        tags: bodyParts.metadata.tags ?? [],
+        location: bodyParts.metadata.location ?? null
+      };
+    });
   } catch (error) {
     console.error(`Failed to get reminders from list "${listName}":`, error);
     throw new Error(
       `Failed to get reminders from list "${listName}": ${getErrorMessage(error)}`
     );
+  }
+}
+
+/**
+ * Get all tags from reminders, optionally filtered by list
+ */
+export async function getTags(listName?: string): Promise<string[]> {
+  try {
+    const tags = new Map<string, string>();
+    const reminderItems = listName
+      ? await fetchRemindersForList(listName, ["name", "body"])
+      : await fetchAllReminders(["name", "body"]);
+
+    for (const reminderItem of reminderItems) {
+      const parsed = parseReminderBody(reminderItem.body);
+      const reminderTags = parsed.metadata.tags ?? [];
+      for (const tag of reminderTags) {
+        const key = tag.toLowerCase();
+        if (!tags.has(key)) {
+          tags.set(key, tag);
+        }
+      }
+    }
+
+    return Array.from(tags.values()).sort((a, b) => a.localeCompare(b));
+  } catch (error) {
+    console.error("Failed to get tags:", error);
+    throw new Error(`Failed to get tags: ${getErrorMessage(error)}`);
   }
 }
 
@@ -106,10 +546,19 @@ export async function createReminder(
   listName: string,
   title: string,
   dueDate?: string,
-  notes?: string
+  notes?: string,
+  flagged?: boolean,
+  priority?: number,
+  tags?: string[],
+  location?: ReminderLocation
 ): Promise<boolean> {
   try {
-    const targetList = await getListByName(listName);
+    const resolvedList = await resolveListByName(listName);
+    if (resolvedList.kind !== "regular") {
+      throw new Error(
+        `Cannot create reminders in smart list "${listName}". Select a regular reminder list.`
+      );
+    }
 
     // Prepare reminder data
     const reminderData: ReminderCreatePayload = {
@@ -120,12 +569,26 @@ export async function createReminder(
       reminderData.dueDate = parseDueDate(dueDate);
     }
 
-    if (notes) {
-      reminderData.body = notes;
+    const normalizedLocation = normalizeLocation(location, true);
+    const reminderBody = composeReminderBody(notes, {
+      tags: normalizeTags(tags),
+      location: normalizedLocation ?? undefined
+    });
+
+    if (reminderBody !== undefined) {
+      reminderData.body = reminderBody;
+    }
+
+    if (typeof flagged === "boolean") {
+      reminderData.flagged = flagged;
+    }
+
+    if (typeof priority === "number") {
+      reminderData.priority = priority;
     }
 
     // Create the reminder
-    const newReminderId = await reminders.createReminder(targetList.id, reminderData);
+    const newReminderId = await reminders.createReminder(resolvedList.list.id, reminderData);
 
     return !!newReminderId;
   } catch (error) {
@@ -135,23 +598,85 @@ export async function createReminder(
 }
 
 /**
+ * Set optional reminder attributes by reminder name
+ */
+export async function setReminderAttributes(
+  listName: string,
+  reminderName: string,
+  attributes: ReminderAttributesUpdate
+): Promise<boolean> {
+  try {
+    const targetReminder = await getReminderByName(listName, reminderName, [
+      "name",
+      "id",
+      "body"
+    ]);
+
+    if (!targetReminder) {
+      return false;
+    }
+
+    const updatePayload: Record<string, unknown> = {};
+
+    if (typeof attributes.flagged === "boolean") {
+      updatePayload.flagged = attributes.flagged;
+    }
+
+    if (typeof attributes.priority === "number") {
+      updatePayload.priority = attributes.priority;
+    }
+
+    if (attributes.tags !== undefined || attributes.location !== undefined) {
+      const bodyParts = parseReminderBody(targetReminder.body);
+      const nextMetadata: ReminderMetadata = { ...bodyParts.metadata };
+
+      if (attributes.tags !== undefined) {
+        const normalizedTags = normalizeTags(attributes.tags);
+        if (normalizedTags.length > 0) {
+          nextMetadata.tags = normalizedTags;
+        } else {
+          delete nextMetadata.tags;
+        }
+      }
+
+      if (attributes.location !== undefined) {
+        const normalizedLocation =
+          attributes.location === null ? null : normalizeLocation(attributes.location, true);
+        if (normalizedLocation) {
+          nextMetadata.location = normalizedLocation;
+        } else {
+          delete nextMetadata.location;
+        }
+      }
+
+      const updatedBody = composeReminderBody(bodyParts.notes ?? undefined, nextMetadata);
+      updatePayload.body = updatedBody ?? "";
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return true;
+    }
+
+    await reminders.updateReminder(
+      targetReminder.id,
+      updatePayload as unknown as Partial<ReminderItem>
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `Failed to set reminder attributes for "${reminderName}" in list "${listName}":`,
+      error
+    );
+    throw new Error(`Failed to set reminder attributes: ${getErrorMessage(error)}`);
+  }
+}
+
+/**
  * Mark a reminder as completed
  */
 export async function completeReminder(listName: string, reminderName: string): Promise<boolean> {
   try {
-    const targetList = await getListByName(listName);
-
-    // Get all reminders from the list
-    const reminderItems = (await reminders.getReminders(
-      targetList.id,
-      ["name", "id"]
-    )) as ReadonlyArray<Partial<ReminderItem>>;
-
-    // Find the specific reminder by name
-    const targetReminder = reminderItems.find(
-      (item): item is Partial<ReminderItem> & { id: string } =>
-        item.name === reminderName && typeof item.id === "string"
-    );
+    const targetReminder = await getReminderByName(listName, reminderName, ["name", "id"]);
 
     if (!targetReminder) {
       return false; // Reminder not found
@@ -174,19 +699,7 @@ export async function completeReminder(listName: string, reminderName: string): 
  */
 export async function deleteReminder(listName: string, reminderName: string): Promise<boolean> {
   try {
-    const targetList = await getListByName(listName);
-
-    // Get all reminders from the list
-    const reminderItems = (await reminders.getReminders(
-      targetList.id,
-      ["name", "id"]
-    )) as ReadonlyArray<Partial<ReminderItem>>;
-
-    // Find the specific reminder by name
-    const targetReminder = reminderItems.find(
-      (item): item is Partial<ReminderItem> & { id: string } =>
-        item.name === reminderName && typeof item.id === "string"
-    );
+    const targetReminder = await getReminderByName(listName, reminderName, ["name", "id"]);
 
     if (!targetReminder) {
       return false; // Reminder not found

--- a/src/tests/test-reminders.ts
+++ b/src/tests/test-reminders.ts
@@ -1,5 +1,11 @@
 import * as reminders from '../reminders.js';
 
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
 /**
  * Test all reminders functions
  */
@@ -13,8 +19,7 @@ async function testReminders() {
     console.log('Available lists:', lists);
     
     if (lists.length === 0) {
-      console.error('No reminder lists found. Please create at least one list in the Reminders app.');
-      return;
+      throw new Error('No reminder lists found. Please create at least one list in the Reminders app.');
     }
     
     // Use the first list for testing
@@ -36,6 +41,7 @@ async function testReminders() {
       'Created by MCP test script'
     );
     console.log('Create result:', createResult);
+    assert(createResult, 'Failed to create reminder');
     
     // Wait a moment for the reminder to be created
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -47,14 +53,14 @@ async function testReminders() {
     console.log('Found created reminder:', createdReminder);
     
     if (!createdReminder) {
-      console.error('Failed to find the created reminder!');
-      return;
+      throw new Error('Failed to find the created reminder');
     }
     
     // Test 5: Mark the reminder as completed
     console.log('\n5. Marking the reminder as completed...');
     const completeResult = await reminders.completeReminder(testList, testReminderTitle);
     console.log('Complete result:', completeResult);
+    assert(completeResult, 'Failed to mark reminder as completed');
     
     // Wait a moment for the reminder to be updated
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -64,11 +70,14 @@ async function testReminders() {
     const completedReminders = await reminders.getRemindersFromList(testList);
     const completedReminder = completedReminders.find(r => r.name === testReminderTitle);
     console.log('Completed reminder:', completedReminder);
+    assert(completedReminder, 'Completed reminder not found');
+    assert(completedReminder.completed, 'Reminder was not marked completed');
     
     // Test 7: Delete the reminder
     console.log('\n7. Deleting the test reminder...');
     const deleteResult = await reminders.deleteReminder(testList, testReminderTitle);
     console.log('Delete result:', deleteResult);
+    assert(deleteResult, 'Failed to delete reminder');
     
     // Wait a moment for the reminder to be deleted
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -78,11 +87,13 @@ async function testReminders() {
     const finalReminders = await reminders.getRemindersFromList(testList);
     const deletedReminder = finalReminders.find(r => r.name === testReminderTitle);
     console.log('Deleted reminder found:', deletedReminder ? 'Yes (error)' : 'No (success)');
+    assert(!deletedReminder, 'Reminder was not deleted');
     
     console.log('\n=== Test Complete ===');
     
   } catch (error) {
     console.error('Test failed with error:', error);
+    process.exitCode = 1;
   }
 }
 

--- a/src/tests/test-reminders.ts
+++ b/src/tests/test-reminders.ts
@@ -6,88 +6,179 @@ function assert(condition: unknown, message: string): asserts condition {
   }
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor<T>(
+  check: () => Promise<T | null | false>,
+  label: string,
+  timeoutMs = 15000,
+  intervalMs = 500
+): Promise<T> {
+  const end = Date.now() + timeoutMs;
+
+  while (Date.now() < end) {
+    const result = await check();
+    if (result) {
+      return result;
+    }
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
 /**
  * Test all reminders functions
  */
 async function testReminders() {
   try {
     console.log('=== Testing Apple Reminders Functions ===');
+    const smartAllList = 'Smart: All';
+    const smartCompletedList = 'Smart: Completed';
     
     // Test 1: Get all reminder lists
     console.log('\n1. Getting all reminder lists...');
     const lists = await reminders.getRemindersLists();
     console.log('Available lists:', lists);
     
-    if (lists.length === 0) {
-      throw new Error('No reminder lists found. Please create at least one list in the Reminders app.');
+    const regularLists = lists.filter((name) => !name.startsWith('Smart:'));
+    if (regularLists.length === 0) {
+      throw new Error('No regular reminder lists found. Please create at least one non-smart list in the Reminders app.');
     }
-    
-    // Use the first list for testing
-    const testList = lists[0];
+
+    assert(lists.includes(smartAllList), 'Smart list "Smart: All" is not available');
+    assert(lists.includes(smartCompletedList), 'Smart list "Smart: Completed" is not available');
+
+    // Use the first regular list for testing
+    const testList = regularLists[0];
     console.log(`\nUsing list "${testList}" for testing...`);
     
     // Test 2: Get reminders from the list
     console.log('\n2. Getting reminders from list...');
     const existingReminders = await reminders.getRemindersFromList(testList);
-    console.log('Existing reminders:', existingReminders);
-    
+    console.log(`Existing reminders count: ${existingReminders.length}`);
+
     // Test 3: Create a new reminder
     const testReminderTitle = `Test Reminder ${new Date().toISOString()}`;
+    const initialTags = ['mcp-test', 'mcp-location'];
     console.log(`\n3. Creating a new reminder: "${testReminderTitle}"...`);
     const createResult = await reminders.createReminder(
       testList, 
       testReminderTitle,
       new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // Due tomorrow
-      'Created by MCP test script'
+      'Created by MCP test script',
+      true,
+      5,
+      initialTags,
+      {
+        title: 'Home',
+        latitude: 37.3349,
+        longitude: -122.009
+      }
     );
     console.log('Create result:', createResult);
     assert(createResult, 'Failed to create reminder');
     
-    // Wait a moment for the reminder to be created
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
     // Test 4: Verify the reminder was created
     console.log('\n4. Verifying the reminder was created...');
-    const updatedReminders = await reminders.getRemindersFromList(testList);
-    const createdReminder = updatedReminders.find(r => r.name === testReminderTitle);
+    const createdReminder = await waitFor(
+      async () => {
+        const updatedReminders = await reminders.getRemindersFromList(testList);
+        return updatedReminders.find(r => r.name === testReminderTitle) ?? null;
+      },
+      'reminder creation'
+    );
     console.log('Found created reminder:', createdReminder);
     
     if (!createdReminder) {
       throw new Error('Failed to find the created reminder');
     }
+
+    assert(createdReminder.flagged, 'Reminder was not created with flagged status');
+    assert(createdReminder.priority === 5, 'Reminder was not created with priority 5');
+    assert(
+      initialTags.every((tag) => createdReminder.tags.includes(tag)),
+      'Reminder was not created with all expected tags'
+    );
+    assert(createdReminder.location?.title === 'Home', 'Reminder was not created with location title');
+
+    // Test 5: Get tag list
+    console.log('\n5. Getting tags...');
+    const tags = await reminders.getTags(testList);
+    console.log('Tags:', tags);
+    assert(tags.includes('mcp-test'), 'Expected tag not found in getTags result');
+
+    // Test 6: Update reminder attributes
+    console.log('\n6. Updating reminder attributes...');
+    const updateResult = await reminders.setReminderAttributes(testList, testReminderTitle, {
+      flagged: false,
+      priority: 1,
+      tags: ['mcp-updated'],
+      location: null
+    });
+    console.log('Update result:', updateResult);
+    assert(updateResult, 'Failed to update reminder attributes');
+
+    // Test 7: Verify attributes were updated
+    console.log('\n7. Verifying reminder attributes were updated...');
+    const updatedReminder = await waitFor(
+      async () => {
+        const updatedReminders = await reminders.getRemindersFromList(testList);
+        return updatedReminders.find(
+          (r) =>
+            r.name === testReminderTitle &&
+            !r.flagged &&
+            r.priority === 1 &&
+            r.tags.length === 1 &&
+            r.tags[0] === 'mcp-updated' &&
+            r.location === null
+        ) ?? null;
+      },
+      'attribute updates'
+    );
+    console.log('Updated reminder:', updatedReminder);
+    assert(updatedReminder, 'Updated reminder not found');
     
-    // Test 5: Mark the reminder as completed
-    console.log('\n5. Marking the reminder as completed...');
+    // Test 8: Mark the reminder as completed
+    console.log('\n8. Marking the reminder as completed...');
     const completeResult = await reminders.completeReminder(testList, testReminderTitle);
     console.log('Complete result:', completeResult);
     assert(completeResult, 'Failed to mark reminder as completed');
     
-    // Wait a moment for the reminder to be updated
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    // Test 6: Verify the reminder was completed
-    console.log('\n6. Verifying the reminder was completed...');
-    const completedReminders = await reminders.getRemindersFromList(testList);
-    const completedReminder = completedReminders.find(r => r.name === testReminderTitle);
+    // Test 9: Verify the reminder was completed
+    console.log('\n9. Verifying the reminder was completed...');
+    const completedReminder = await waitFor(
+      async () => {
+        const completedReminders = await reminders.getRemindersFromList(testList);
+        return completedReminders.find(
+          (r) => r.name === testReminderTitle && r.completed
+        ) ?? null;
+      },
+      'reminder completion'
+    );
     console.log('Completed reminder:', completedReminder);
     assert(completedReminder, 'Completed reminder not found');
     assert(completedReminder.completed, 'Reminder was not marked completed');
     
-    // Test 7: Delete the reminder
-    console.log('\n7. Deleting the test reminder...');
+    // Test 10: Delete the reminder
+    console.log('\n10. Deleting the test reminder...');
     const deleteResult = await reminders.deleteReminder(testList, testReminderTitle);
     console.log('Delete result:', deleteResult);
     assert(deleteResult, 'Failed to delete reminder');
     
-    // Wait a moment for the reminder to be deleted
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    // Test 8: Verify the reminder was deleted
-    console.log('\n8. Verifying the reminder was deleted...');
-    const finalReminders = await reminders.getRemindersFromList(testList);
-    const deletedReminder = finalReminders.find(r => r.name === testReminderTitle);
-    console.log('Deleted reminder found:', deletedReminder ? 'Yes (error)' : 'No (success)');
-    assert(!deletedReminder, 'Reminder was not deleted');
+    // Test 11: Verify the reminder was deleted
+    console.log('\n11. Verifying the reminder was deleted...');
+    const deleted = await waitFor(
+      async () => {
+        const finalReminders = await reminders.getRemindersFromList(testList);
+        return !finalReminders.some((r) => r.name === testReminderTitle);
+      },
+      'reminder deletion'
+    );
+    console.log('Deleted reminder found:', deleted ? 'No (success)' : 'Yes (error)');
+    assert(deleted, 'Reminder was not deleted');
     
     console.log('\n=== Test Complete ===');
     

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@hono/node-server@^1.19.9":
+  version "1.19.9"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.9.tgz#8f37119b1acf283fd3f6035f3d1356fdb97a09ac"
+  integrity sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.2"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
@@ -27,20 +32,28 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@modelcontextprotocol/sdk@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.6.1.tgz"
-  integrity sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==
+"@modelcontextprotocol/sdk@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz#5b35d73062125f126cc70b0be83cbab53bcdde74"
+  integrity sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==
   dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
     content-type "^1.0.5"
     cors "^2.8.5"
+    cross-spawn "^7.0.5"
     eventsource "^3.0.2"
-    express "^5.0.1"
-    express-rate-limit "^7.5.0"
-    pkce-challenge "^4.1.0"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
     raw-body "^3.0.0"
-    zod "^3.23.8"
-    zod-to-json-schema "^3.24.1"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
@@ -77,25 +90,24 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@^4.17.33":
-  version "4.19.6"
-  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz"
-  integrity sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==
+"@types/express-serve-static-core@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
+  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.17":
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz"
-  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
+"@types/express@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
+  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.33"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
+    "@types/express-serve-static-core" "^5.0.0"
+    "@types/serve-static" "^2"
 
 "@types/http-errors@*":
   version "2.0.4"
@@ -107,12 +119,19 @@
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
-"@types/node@*", "@types/node@^18.15.11":
+"@types/node@*":
   version "18.19.79"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.19.79.tgz"
   integrity sha512-90K8Oayimbctc5zTPHPfZloc/lGVs7f3phUAAMcTgEPtg8kKquGZDERC8K4vkBYkQQh48msiYUslYtxTWvqcAg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^25.2.3":
+  version "25.2.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.3.tgz#9c18245be768bdb4ce631566c7da303a5c99a7f8"
+  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/qs@*":
   version "6.9.18"
@@ -132,14 +151,13 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-static@*":
-  version "1.15.7"
-  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz"
-  integrity sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==
+"@types/serve-static@^2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
+  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
   dependencies:
     "@types/http-errors" "*"
     "@types/node" "*"
-    "@types/send" "*"
 
 accepts@^2.0.0:
   version "2.0.0"
@@ -148,14 +166,6 @@ accepts@^2.0.0:
   dependencies:
     mime-types "^3.0.0"
     negotiator "^1.0.0"
-
-accepts@~1.3.8:
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
-  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
-  dependencies:
-    mime-types "~2.1.34"
-    negotiator "0.6.3"
 
 acorn-walk@^8.1.1:
   version "8.3.4"
@@ -169,50 +179,44 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv@^8.0.0, ajv@^8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-array-flatten@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-  integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
-
-body-parser@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/body-parser/-/body-parser-2.1.0.tgz"
-  integrity sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
   dependencies:
     bytes "^3.1.2"
     content-type "^1.0.5"
-    debug "^4.4.0"
+    debug "^4.4.3"
     http-errors "^2.0.0"
-    iconv-lite "^0.5.2"
+    iconv-lite "^0.7.0"
     on-finished "^2.4.1"
-    qs "^6.14.0"
-    raw-body "^3.0.0"
-    type-is "^2.0.0"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
 
-body-parser@1.20.3:
-  version "1.20.3"
-  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz"
-  integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.5"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.13.0"
-    raw-body "2.5.2"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
-bytes@^3.1.2, bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -240,14 +244,7 @@ content-disposition@^1.0.0:
   dependencies:
     safe-buffer "5.2.1"
 
-content-disposition@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
-  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
-  dependencies:
-    safe-buffer "5.2.1"
-
-content-type@^1.0.5, content-type@~1.0.4, content-type@~1.0.5:
+content-type@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -257,15 +254,10 @@ cookie-signature@^1.2.1:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz"
   integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
 
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
-
-cookie@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz"
-  integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -280,49 +272,35 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.5:
   version "7.0.6"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.3.5:
+debug@^4.3.5, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
 
-debug@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
-debug@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@4.3.6:
-  version "4.3.6"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
-  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
-  dependencies:
-    ms "2.1.2"
-
-depd@2.0.0:
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@^1.2.0, destroy@1.2.0:
+destroy@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -346,15 +324,10 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-encodeurl@^2.0.0, encodeurl@~2.0.0:
+encodeurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
-
-encodeurl@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
-  integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -380,12 +353,12 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-etag@^1.8.1, etag@~1.8.1:
+etag@^1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
@@ -417,90 +390,61 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-express-rate-limit@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz"
-  integrity sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==
+express-rate-limit@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.2.1.tgz#ec75fdfe280ecddd762b8da8784c61bae47d7f7f"
+  integrity sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==
+  dependencies:
+    ip-address "10.0.1"
 
-"express@^4.11 || 5 || ^5.0.0-beta.1", express@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/express/-/express-5.0.1.tgz"
-  integrity sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==
+express@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
   dependencies:
     accepts "^2.0.0"
-    body-parser "^2.0.1"
+    body-parser "^2.2.1"
     content-disposition "^1.0.0"
-    content-type "~1.0.4"
-    cookie "0.7.1"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
     cookie-signature "^1.2.1"
-    debug "4.3.6"
-    depd "2.0.0"
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "^2.0.0"
-    fresh "2.0.0"
-    http-errors "2.0.0"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
     merge-descriptors "^2.0.0"
-    methods "~1.1.2"
     mime-types "^3.0.0"
-    on-finished "2.4.1"
-    once "1.4.0"
-    parseurl "~1.3.3"
-    proxy-addr "~2.0.7"
-    qs "6.13.0"
-    range-parser "~1.2.1"
-    router "^2.0.0"
-    safe-buffer "5.2.1"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
     send "^1.1.0"
-    serve-static "^2.1.0"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "^2.0.0"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
-express@^4.18.2:
-  version "4.21.2"
-  resolved "https://registry.npmjs.org/express/-/express-4.21.2.tgz"
-  integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.3"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.7.1"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.3.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.3"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.12"
-    proxy-addr "~2.0.7"
-    qs "6.13.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.19.0"
-    serve-static "1.16.2"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-finalhandler@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz"
-  integrity sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+
+finalhandler@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
+  integrity sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==
   dependencies:
     debug "^4.4.0"
     encodeurl "^2.0.0"
@@ -508,19 +452,6 @@ finalhandler@^2.0.0:
     on-finished "^2.4.1"
     parseurl "^1.3.3"
     statuses "^2.0.1"
-
-finalhandler@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz"
-  integrity sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==
-  dependencies:
-    debug "2.6.9"
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    statuses "2.0.1"
-    unpipe "~1.0.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -532,14 +463,9 @@ fresh@^0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
-fresh@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
-  integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
-
-fresh@2.0.0:
+fresh@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 function-bind@^1.1.2:
@@ -595,7 +521,12 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-http-errors@^2.0.0, http-errors@2.0.0:
+hono@^4.11.4:
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.11.9.tgz#4e0dec5309a8f05216c777cbd93131a41cf28eb9"
+  integrity sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==
+
+http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz"
   integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
@@ -606,24 +537,21 @@ http-errors@^2.0.0, http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-errors@^2.0.1, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
-
-iconv-lite@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz"
-  integrity sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@0.4.24:
-  version "0.4.24"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@0.6.3:
   version "0.6.3"
@@ -632,10 +560,22 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-inherits@2.0.4:
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+inherits@2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ip-address@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.0.1.tgz#a8180b783ce7788777d796286d61bce4276818ed"
+  integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -657,6 +597,21 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+jose@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.3.tgz#8453d7be88af7bb7d64a0481d6a35a0145ba3ea5"
+  integrity sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
@@ -672,40 +627,30 @@ media-typer@^1.1.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz"
   integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-  integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
-
 merge-descriptors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz"
   integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
-
-merge-descriptors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz"
-  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-methods@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-db@^1.53.0:
   version "1.53.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz"
   integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
 mime-types@^2.1.35:
   version "2.1.35"
@@ -721,17 +666,12 @@ mime-types@^3.0.0:
   dependencies:
     mime-db "^1.53.0"
 
-mime-types@~2.1.24, mime-types@~2.1.34:
-  version "2.1.35"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+mime-types@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
   dependencies:
-    mime-db "1.52.0"
-
-mime@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
-  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+    mime-db "^1.54.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -743,34 +683,14 @@ ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
-negotiator@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
-  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
 node-reminders@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/node-reminders/-/node-reminders-1.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/node-reminders/-/node-reminders-1.0.0.tgz#30d2912ca9e3fc8d2ebda36d84460a1cb91dc6f2"
   integrity sha512-fDTkCIS8BUvedtbBXBsc9U/THH4j//1InSxpYdKO6bx2L8Sf6e5x5s1bb5vlp1ikHG7gLI3M+yTbYuwc+vmH8Q==
   dependencies:
     execa "^4.0.0"
@@ -792,14 +712,14 @@ object-inspect@^1.13.3:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
-on-finished@^2.4.1, on-finished@2.4.1:
+on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.1, once@^1.4.0, once@1.4.0:
+once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -813,7 +733,7 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-parseurl@^1.3.3, parseurl@~1.3.3:
+parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -828,19 +748,14 @@ path-to-regexp@^8.0.0:
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz"
   integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
 
-path-to-regexp@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
 
-pkce-challenge@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz"
-  integrity sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==
-
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7:
   version "2.0.7"
-  resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
   dependencies:
     forwarded "0.2.0"
@@ -861,14 +776,14 @@ qs@^6.14.0:
   dependencies:
     side-channel "^1.1.0"
 
-qs@6.13.0:
-  version "6.13.0"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz"
-  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+qs@^6.14.1:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
   dependencies:
-    side-channel "^1.0.6"
+    side-channel "^1.1.0"
 
-range-parser@^1.2.1, range-parser@~1.2.1:
+range-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
@@ -883,21 +798,28 @@ raw-body@^3.0.0:
     iconv-lite "0.6.3"
     unpipe "1.0.0"
 
-raw-body@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz"
-  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
+raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
   dependencies:
-    bytes "3.1.2"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
-router@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/router/-/router-2.1.0.tgz"
-  integrity sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
   dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
     is-promise "^4.0.0"
     parseurl "^1.3.3"
     path-to-regexp "^8.0.0"
@@ -907,12 +829,12 @@ safe-buffer@5.2.1:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-send@^1.0.0, send@^1.1.0:
+send@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/send/-/send-1.1.0.tgz"
   integrity sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==
@@ -930,46 +852,34 @@ send@^1.0.0, send@^1.1.0:
     range-parser "^1.2.1"
     statuses "^2.0.1"
 
-send@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.npmjs.org/send/-/send-0.19.0.tgz"
-  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
+send@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
+  integrity sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==
   dependencies:
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    mime "1.6.0"
-    ms "2.1.3"
-    on-finished "2.4.1"
-    range-parser "~1.2.1"
-    statuses "2.0.1"
+    debug "^4.4.3"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.1"
+    mime-types "^3.0.2"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.2"
 
-serve-static@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz"
-  integrity sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==
+serve-static@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
+  integrity sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==
   dependencies:
     encodeurl "^2.0.0"
     escape-html "^1.0.3"
     parseurl "^1.3.3"
-    send "^1.0.0"
+    send "^1.2.0"
 
-serve-static@1.16.2:
-  version "1.16.2"
-  resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz"
-  integrity sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==
-  dependencies:
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    parseurl "~1.3.3"
-    send "0.19.0"
-
-setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -1015,7 +925,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.6, side-channel@^1.1.0:
+side-channel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz"
   integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
@@ -1031,24 +941,29 @@ signal-exit@^3.0.2:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-statuses@^2.0.1, statuses@2.0.1:
+statuses@2.0.1, statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+statuses@^2.0.2, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-toidentifier@1.0.1:
+toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-ts-node@^10.9.1:
+ts-node@^10.9.2:
   version "10.9.2"
-  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
@@ -1065,54 +980,41 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-type-is@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz"
-  integrity sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==
+type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
   dependencies:
     content-type "^1.0.5"
     media-typer "^1.1.0"
     mime-types "^3.0.0"
 
-type-is@~1.6.18:
-  version "1.6.18"
-  resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
-
-typescript@^5.0.4, typescript@>=2.7:
-  version "5.8.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz"
-  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici-types@~6.20.0:
-  version "6.20.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz"
-  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-unpipe@~1.0.0, unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
-
-utils-merge@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
-  integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -1134,12 +1036,12 @@ yn@3.1.1:
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zod-to-json-schema@^3.24.1:
-  version "3.24.3"
-  resolved "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz"
-  integrity sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==
+zod-to-json-schema@^3.25.1:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
+  integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
-zod@^3.22.4, zod@^3.23.8, zod@^3.24.1:
-  version "3.24.2"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz"
-  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==
+"zod@^3.25 || ^4.0", zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,89 +75,12 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@types/body-parser@*":
-  version "1.19.5"
-  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz"
-  integrity sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
-"@types/connect@*":
-  version "3.4.38"
-  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz"
-  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
-  dependencies:
-    "@types/node" "*"
-
-"@types/express-serve-static-core@^5.0.0":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
-  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-    "@types/send" "*"
-
-"@types/express@^5.0.6":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
-  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^5.0.0"
-    "@types/serve-static" "^2"
-
-"@types/http-errors@*":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz"
-  integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
-
-"@types/mime@^1":
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz"
-  integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
-
-"@types/node@*":
-  version "18.19.79"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.79.tgz"
-  integrity sha512-90K8Oayimbctc5zTPHPfZloc/lGVs7f3phUAAMcTgEPtg8kKquGZDERC8K4vkBYkQQh48msiYUslYtxTWvqcAg==
-  dependencies:
-    undici-types "~5.26.4"
-
 "@types/node@^25.2.3":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.3.tgz#9c18245be768bdb4ce631566c7da303a5c99a7f8"
   integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
   dependencies:
     undici-types "~7.16.0"
-
-"@types/qs@*":
-  version "6.9.18"
-  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz"
-  integrity sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==
-
-"@types/range-parser@*":
-  version "1.2.7"
-  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
-  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
-
-"@types/send@*":
-  version "0.17.4"
-  resolved "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz"
-  integrity sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==
-  dependencies:
-    "@types/mime" "^1"
-    "@types/node" "*"
-
-"@types/serve-static@^2":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
-  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
-  dependencies:
-    "@types/http-errors" "*"
-    "@types/node" "*"
 
 accepts@^2.0.0:
   version "2.0.0"
@@ -993,11 +916,6 @@ typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
-
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
## Summary
- add virtual smart lists to `getLists` and allow `getReminders`, `completeReminder`, and `deleteReminder` to target smart-list names (`Smart: All`, `Smart: Today`, `Smart: Scheduled`, `Smart: Flagged`, `Smart: Completed`, `Smart: Overdue`)
- expand reminder payloads to include `flagged`, `priority`, `tags`, and `location`
- add new tools: `getTags` and `setReminderAttributes`
- standardize tool responses and input validation in the MCP server entrypoint
- improve README coverage for setup, tool contracts, and metadata behavior

## Implementation Details
- `src/reminders.ts`
  - refactor list resolution to support both regular lists and virtual smart lists
  - add metadata encoding/decoding in reminder body for tags/location persistence
  - add helper APIs for fetching tags and updating reminder attributes
  - improve date parsing and error handling for clearer failures
- `src/index.ts`
  - add shared success/error response helpers
  - strengthen Zod validation for list names, due dates, priority, tags, and location
  - register `getTags` and `setReminderAttributes` tools
- `src/tests/test-reminders.ts`
  - extend integration coverage for flagged/priority/tags/location create+update flows

## Validation
- `yarn build` passes
- `yarn test` starts and validates create/read/tag/update setup paths, but the run did not complete in this environment (hung during the post-update verification stage)

## Changed Files
- `.gitignore`
- `README.md`
- `package.json`
- `src/index.ts`
- `src/reminders.ts`
- `src/tests/test-reminders.ts`
- `yarn.lock`
